### PR TITLE
Default TLS to true via entrypoint

### DIFF
--- a/docker/docker-compose.dnsmasq.yml
+++ b/docker/docker-compose.dnsmasq.yml
@@ -31,7 +31,6 @@ services:
       "]
     labels:
       - traefik.enable=true
-      - traefik.http.routers.dnsmasq.tls=true
       - traefik.http.routers.dnsmasq.rule=Host(`dnsmasq.${WARDEN_SERVICE_DOMAIN:-warden.test}`)
       - traefik.http.services.dnsmasq.loadbalancer.server.port=8080
     restart: ${WARDEN_RESTART_POLICY:-always}

--- a/docker/docker-compose.mailpit.yml
+++ b/docker/docker-compose.mailpit.yml
@@ -8,13 +8,11 @@ services:
       - mailpitdata:/data
     labels:
       traefik.enable: true
-      traefik.http.routers.mailpit.tls: true
       traefik.http.routers.mailpit.priority: 2
       traefik.http.routers.mailpit.rule: Host(`webmail.${WARDEN_SERVICE_DOMAIN:-warden.test}`)
       traefik.http.routers.mailpit.service: mailpit
       traefik.http.services.mailpit.loadbalancer.server.port: 8025
       # Legacy Mailhog redirect
-      traefik.http.routers.legacy-mailhog.tls: true
       traefik.http.routers.legacy-mailhog.priority: 1
       traefik.http.routers.legacy-mailhog.rule: Host(`mailhog.${WARDEN_SERVICE_DOMAIN:-warden.test}`)
       traefik.http.routers.legacy-mailhog.middlewares: legacy-mailhog-redirect

--- a/docker/docker-compose.portainer.yml
+++ b/docker/docker-compose.portainer.yml
@@ -7,7 +7,6 @@ services:
       - portainer:/data
     labels:
       - traefik.enable=true
-      - traefik.http.routers.portainer.tls=true
       - traefik.http.routers.portainer.rule=Host(`portainer.${WARDEN_SERVICE_DOMAIN:-den.test}`)||Host(`portainer.warden.test`)
       - traefik.http.services.portainer.loadbalancer.server.port=9000
     restart: ${WARDEN_RESTART_POLICY:-always}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,7 +11,6 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     labels:
       - traefik.enable=true
-      - traefik.http.routers.traefik.tls=true
       - traefik.http.routers.traefik.rule=Host(`traefik.${WARDEN_SERVICE_DOMAIN:-warden.test}`)
       - traefik.http.routers.traefik.service=api@internal
     restart: ${WARDEN_RESTART_POLICY:-always}
@@ -29,6 +28,8 @@ services:
       TRAEFIK_ENTRYPOINTS_HTTP_HTTP_REDIRECTIONS_ENTRYPOINT_TO: https
       TRAEFIK_ENTRYPOINTS_HTTPS: true
       TRAEFIK_ENTRYPOINTS_HTTPS_ADDRESS: :443
+      TRAEFIK_ENTRYPOINTS_HTTPS_HTTP: true
+      TRAEFIK_ENTRYPOINTS_HTTPS_HTTP_TLS: true
       TRAEFIK_LOG: true
       TRAEFIK_LOG_LEVEL: info
       TRAEFIK_GLOBAL_CHECKNEWVERSION: false

--- a/environments/includes/allure.base.yml
+++ b/environments/includes/allure.base.yml
@@ -4,12 +4,10 @@ services:
     image: frankescobar/allure-docker-service:latest
     labels:
       - traefik.enable=true
-      - traefik.http.routers.${WARDEN_ENV_NAME}-allure.tls=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-allure.rule=Host(`allure.${TRAEFIK_DOMAIN}`)
       - traefik.http.services.${WARDEN_ENV_NAME}-allure.loadbalancer.server.port=4040
       - traefik.docker.network=${WARDEN_ENV_NAME}_default
       # TODO; configure the Allure API; these rules result in allure sub-domain no longer routing
-      # - traefik.http.routers.${WARDEN_ENV_NAME}-allure-api.tls=true
       # - traefik.http.routers.${WARDEN_ENV_NAME}-allure-api.rule=Host(`allure-api.${TRAEFIK_DOMAIN}`)
       # - traefik.http.services.${WARDEN_ENV_NAME}-allure-api.loadbalancer.server.port=5050
     volumes:

--- a/environments/includes/elastichq.base.yml
+++ b/environments/includes/elastichq.base.yml
@@ -4,7 +4,6 @@ services:
     image: elastichq/elasticsearch-hq:latest
     labels:
       - traefik.enable=true
-      - traefik.http.routers.${WARDEN_ENV_NAME}-elasticsearch-hq.tls=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-elasticsearch-hq.rule=Host(`elastichq.${TRAEFIK_DOMAIN}`)
       - traefik.http.services.${WARDEN_ENV_NAME}-elasticsearch-hq.loadbalancer.server.port=5000
       - traefik.docker.network=${WARDEN_ENV_NAME}_default

--- a/environments/includes/elasticsearch.base.yml
+++ b/environments/includes/elasticsearch.base.yml
@@ -4,7 +4,6 @@ services:
     image: ${WARDEN_IMAGE_REPOSITORY}/elasticsearch:${ELASTICSEARCH_VERSION:-8.11}
     labels:
       - traefik.enable=true
-      - traefik.http.routers.${WARDEN_ENV_NAME}-elasticsearch.tls=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-elasticsearch.rule=Host(`elasticsearch.${TRAEFIK_DOMAIN}`)
       - traefik.http.services.${WARDEN_ENV_NAME}-elasticsearch.loadbalancer.server.port=9200
       - traefik.docker.network=${WARDEN_ENV_NAME}_default

--- a/environments/includes/nginx.base.yml
+++ b/environments/includes/nginx.base.yml
@@ -4,7 +4,6 @@ services:
     image: ${WARDEN_IMAGE_REPOSITORY}/nginx:${NGINX_VERSION:-1.16}
     labels:
       - traefik.enable=true
-      - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.tls=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.priority=2
       - traefik.http.routers.${WARDEN_ENV_NAME}-nginx.rule=
           HostRegexp(`{subdomain:.+}.${TRAEFIK_DOMAIN}`) || Host(`${TRAEFIK_DOMAIN}`)

--- a/environments/includes/opensearch.base.yml
+++ b/environments/includes/opensearch.base.yml
@@ -4,7 +4,6 @@ services:
     image: ${WARDEN_IMAGE_REPOSITORY}/opensearch:${OPENSEARCH_VERSION:-1.2}
     labels:
       - traefik.enable=true
-      - traefik.http.routers.${WARDEN_ENV_NAME}-opensearch.tls=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-opensearch.rule=Host(`opensearch.${TRAEFIK_DOMAIN}`)
       - traefik.http.services.${WARDEN_ENV_NAME}-opensearch.loadbalancer.server.port=9200
       - traefik.docker.network=${WARDEN_ENV_NAME}_default

--- a/environments/includes/rabbitmq.base.yml
+++ b/environments/includes/rabbitmq.base.yml
@@ -4,7 +4,6 @@ services:
     image: ${WARDEN_IMAGE_REPOSITORY}/rabbitmq:${RABBITMQ_VERSION:-3.8}
     labels:
       - traefik.enable=true
-      - traefik.http.routers.${WARDEN_ENV_NAME}-rabbitmq.tls=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-rabbitmq.rule=Host(`rabbitmq.${TRAEFIK_DOMAIN}`)
       - traefik.http.services.${WARDEN_ENV_NAME}-rabbitmq.loadbalancer.server.port=15672
       - traefik.docker.network=${WARDEN_ENV_NAME}_default

--- a/environments/includes/varnish.base.yml
+++ b/environments/includes/varnish.base.yml
@@ -12,7 +12,6 @@ services:
       - nginx
     labels:
       - traefik.enable=true
-      - traefik.http.routers.${WARDEN_ENV_NAME}-varnish.tls=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-varnish.priority=1
       - traefik.http.routers.${WARDEN_ENV_NAME}-varnish.rule=
           HostRegexp(`{subdomain:.+}.${TRAEFIK_DOMAIN}`) || Host(`${TRAEFIK_DOMAIN}`)

--- a/environments/magento2/magento2.base.yml
+++ b/environments/magento2/magento2.base.yml
@@ -7,7 +7,6 @@ services:
   php-fpm:
     labels:
       - traefik.enable=true
-      - traefik.http.routers.${WARDEN_ENV_NAME}-livereload.tls=true
       - traefik.http.routers.${WARDEN_ENV_NAME}-livereload.priority=3
       - traefik.http.routers.${WARDEN_ENV_NAME}-livereload.rule=
           (HostRegexp(`{subdomain:.+}.${TRAEFIK_DOMAIN}`) || Host(`${TRAEFIK_DOMAIN}`))


### PR DESCRIPTION
Enable TLS on the entrypoint instead of per router. 

This simplifies enabling custom certificate resolvers, as we can just define them via the entrypoint instead of per router.

Dependent on #2 - Migrate Traefik config to ENV vars

---

When paired with #2 We can define Traefik TLS certificate resolvers in the file `~/.warden/docker-compose.yml`.

Example content for a Cloudflare DNS resolver
```yml
services:
  traefik:
    volumes:
      - acmedata:/acme
    environment:
      CF_DNS_API_TOKEN: xxxxxx
      CF_ZONE_API_TOKEN: xxxxxx
      TRAEFIK_ENTRYPOINTS_HTTPS_HTTP_TLS_CERTRESOLVER: letsencrypt
      TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT: true
      TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_EMAIL: admin@example.com
      TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_STORAGE: /acme/acme.json
      TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_CASERVER: https://acme-staging-v02.api.letsencrypt.org/directory
      TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_DNSCHALLENGE: true
      TRAEFIK_CERTIFICATESRESOLVERS_LETSENCRYPT_ACME_DNSCHALLENGE_PROVIDER: cloudflare
volumes:
  acmedata:
```