### PR TITLE
fix: prevent clobbering certs

### DIFF
--- a/commands/svc.cmd
+++ b/commands/svc.cmd
@@ -70,15 +70,15 @@ if [[ "${WARDEN_PARAMS[0]}" == "up" ]]; then
 		  stores:
 		    default:
 		      defaultCertificate:
-		        certFile: /etc/ssl/certs/${WARDEN_SERVICE_DOMAIN}.crt.pem
-		        keyFile: /etc/ssl/certs/${WARDEN_SERVICE_DOMAIN}.key.pem
+		        certFile: /etc/ssl/certs/warden/${WARDEN_SERVICE_DOMAIN}.crt.pem
+		        keyFile: /etc/ssl/certs/warden/${WARDEN_SERVICE_DOMAIN}.key.pem
 		  certificates:
 	EOT
 
     for cert in $(find "${WARDEN_SSL_DIR}/certs" -type f -name "*.crt.pem" | sed -E 's#^.*/ssl/certs/(.*)\.crt\.pem$#\1#'); do
         cat >> "${WARDEN_HOME_DIR}/etc/traefik/dynamic.yml" <<-EOF
-		    - certFile: /etc/ssl/certs/${cert}.crt.pem
-		      keyFile: /etc/ssl/certs/${cert}.key.pem
+		    - certFile: /etc/ssl/certs/warden/${cert}.crt.pem
+		      keyFile: /etc/ssl/certs/warden/${cert}.key.pem
 		EOF
     done
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     volumes:
       - ${WARDEN_HOME_DIR}/etc/traefik/traefik.yml:/etc/traefik/traefik.yml
       - ${WARDEN_HOME_DIR}/etc/traefik/dynamic.yml:/etc/traefik/dynamic.yml
-      - ${WARDEN_HOME_DIR}/ssl/certs:/etc/ssl/certs
+      - ${WARDEN_HOME_DIR}/ssl/certs:/etc/ssl/certs/warden
       - /var/run/docker.sock:/var/run/docker.sock
     labels:
       - traefik.enable=true


### PR DESCRIPTION
Prevent clobbering system level certs, since it breaks Traefik being able to fetch plugins from remotes.